### PR TITLE
look in zip for labeled list

### DIFF
--- a/app_files/src/app_funcs.py
+++ b/app_files/src/app_funcs.py
@@ -27,6 +27,7 @@ from glob import glob
 import dash_html_components as html
 import io, os, psutil, logging, base64, PIL.Image
 from plot_utils import dummy_fig, add_layout_images_to_fig
+import zipfile
 
 ##========================================================
 def get_asset_files():
@@ -91,6 +92,17 @@ def uploaded_files(filelist,UPLOAD_DIRECTORY,LABELED_DIRECTORY):
                 labeled_files.append(filename)
             if 'jpeg' in filename:
                 labeled_files.append(filename)
+            if 'zip' in filename:
+                zipF = zipfile.ZipFile(path)
+                zfilelist = zipF.namelist()
+                for zfiles in zfilelist:
+                    if 'jpg' in zfiles:
+                        labeled_files.append(zfiles)
+                    if 'JPG' in zfiles:
+                        labeled_files.append(zfiles)
+                    if 'jpeg' in zfiles:
+                        labeled_files.append(zfiles)
+                
 
     with open(filelist, 'w') as filehandle:
         for listitem in labeled_files:


### PR DESCRIPTION
During doodling, the labeled images are copied in to the `/labeled` directory. This directory is checked by the app to generate the list of images that have been previously labeled and omit them from the list of images that could be labeled.

At the beginning of every session, the files in `/labeled` are zipped up. Images that have been labeled from previous sessions are in the zip, and therefore not caught by the app_funcs.py and therefore not included in the `labeled_files` list (line 94 of `apps_funcs.py`). this can result in duplicate labeling by a user if they doodle a group of images over multiple sessions.

This PR adds some new lines of code that will open the zip files in `/labeled` and add the `*.jpg` files in the zip to the `labeled_files` list. 

zipfile is now a imported to allow this functionality